### PR TITLE
SRE-2535: add license as expected by OpenSSF Scorecard

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,40 +1,8 @@
 #!/usr/bin/groovy
-/* Copyright (C) 2019-2024 Intel Corporation
- * All rights reserved.
+/*
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted for any purpose (including commercial purposes)
- * provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions, and the following disclaimer in the
- *    documentation and/or materials provided with the distribution.
- *
- * 3. In addition, redistributions of modified forms of the source or binary
- *    code must carry prominent notices stating that the original code was
- *    changed and the date of the change.
- *
- *  4. All publications or advertising materials mentioning features or use of
- *     this software are asked, but not required, to acknowledge that it was
- *     developed by Intel Corporation and credit the contributors.
- *
- * 5. Neither the name of Intel Corporation, nor the name of any Contributor
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (C) 2019-2024 Intel Corporation
  */
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
 #!/usr/bin/groovy
-/*
- * SPDX-License-Identifier: BSD-2-Clause-Patent
- *
- * Copyright (C) 2019-2024 Intel Corporation
- */
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+// Copyright (c) 2019-2024 Intel Corporation
+
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,54 @@
+BSD-2-Clause Plus Patent License
+
+Copyright 2019-2024 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+Subject to the terms and conditions of this license, each copyright
+holder and contributor hereby grants to those receiving rights under
+this license a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except for failure to satisfy the conditions
+of this license) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer this software, where such license
+applies only to those patent claims, already acquired or hereafter
+acquired, licensable by such copyright holder or contributor that are
+necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders
+    and non-copyrightable additions of contributors, in source or
+    binary form) alone; or
+
+(b) combination of their Contribution(s) with the work of authorship to
+    which such Contribution(s) was added by such copyright holder or
+    contributor, if, at the time the Contribution is added, such
+    addition causes such combination to be necessarily infringed.
+    The patent license shall not apply to any other combinations which
+    include the Contribution.
+
+Except as expressly stated above, no rights or licenses from any
+copyright holder or contributor is granted under this license, whether
+expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD-2-Clause Plus Patent License
 
-Copyright 2019-2024 Intel Corporation.
+Copyright (c) 2019-2024 Intel Corporation
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
-# Copyright (C) 2019-2024 Intel Corporation
+# Copyright (c) 2019-2024 Intel Corporation
 NAME    := fio
 SRC_EXT := bz2
 SOURCE   = http://brick.kernel.dk/snaps/$(NAME)-$(VERSION).tar.$(SRC_EXT)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (C) 2019-2024 Intel Corporation
 NAME    := fio
 SRC_EXT := bz2
 SOURCE   = http://brick.kernel.dk/snaps/$(NAME)-$(VERSION).tar.$(SRC_EXT)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # Copyright (c) 2019-2024 Intel Corporation
+
 NAME    := fio
 SRC_EXT := bz2
 SOURCE   = http://brick.kernel.dk/snaps/$(NAME)-$(VERSION).tar.$(SRC_EXT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
-# DISCONTINUATION OF PROJECT #
-This project will no longer be maintained by Intel.
-Intel has ceased development and contributions including, but not limited to, maintenance, bug fixes, new releases, or updates, to this project.
-Intel no longer accepts patches to this project.
 # fio
 RPM packaging of fio


### PR DESCRIPTION
Inherit BSD-2-Clause-Patent License
from the main - daos-stack/daos project.